### PR TITLE
Add support for rerunning when promise changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,13 +30,16 @@ $ yarn add react@16.7.0-alpha.0 react-dom@16.7.0-alpha.0
 ## Usage
 
 ```js
-import React from 'react';
+import React, { useMemo } from 'react';
 import usePromise from 'react-use-promise';
 
 function Example() {
-  const [result, error] = usePromise(() => new Promise(resolve => {
-    setTimeout(() => resolve('foo'), 2000);
-  }));
+  const [result, error] = usePromise(useMemo(
+    () => new Promise(resolve => {
+      setTimeout(() => resolve('foo'), 2000);
+    }),
+    []
+  ));
 
   return (
     <p>
@@ -49,11 +52,31 @@ function Example() {
 ## API
 
 ```js
-usePromise(() => Promise): [any, any]
+usePromise(Promise | () => Promise): [any, any]
 ```
 
-Receives a function that returns a promise and returns a tuple
+Receives a promise or a function that returns a promise and returns a tuple
 with the promise's result and error.
+
+**Note:** You'll probably want to avoid passing new promises on each render.
+This can happen if you do something like this:
+
+```js
+const [response, error] = usePromise(fetch(url));
+```
+
+This will call `fetch` on every render, which will return a new promise each time.
+In this case, wrap the promise in `useMemo` or `useCallback`, so that you only pass
+a new promise when something changes. Example:
+
+```js
+const [response, error] = usePromise(useMemo(
+  () => fetch(url),
+  [url]
+));
+```
+
+This will only call `fetch` when the `url` changes.
 
 ## Contributing
 

--- a/example/index.js
+++ b/example/index.js
@@ -1,23 +1,18 @@
 import { render } from 'react-dom';
-import React from 'react';
+import React, { useMemo } from 'react';
 import usePromise from '../src';
 
 const Example = () => {
-  const [result, error] = usePromise(() => new Promise(resolve => {
-    setTimeout(() => resolve('foo'), 2000);
-  }));
-
-  if (error) {
-    return (
-      <p>
-        {error.message}
-      </p>
-    );
-  }
+  const [result, error] = usePromise(useMemo(
+    () => new Promise(resolve => {
+      setTimeout(() => resolve('foo'), 2000);
+    }),
+    []
+  ));
 
   return (
     <p>
-      {result}
+      {result || error}
     </p>
   );
 };

--- a/src/index.js
+++ b/src/index.js
@@ -1,13 +1,27 @@
 import { useEffect, useState } from 'react';
 
+function resolvePromise(promise) {
+  if (typeof promise === 'function') {
+    return promise();
+  }
+
+  return promise;
+}
+
 function usePromise(promise) {
   const [result, setResult] = useState(null);
   const [error, setError] = useState(null);
 
   useEffect(() => {
+    promise = resolvePromise(promise);
+
+    if (!promise) {
+      return;
+    }
+
     let canceled = false;
 
-    promise().then(
+    promise.then(
       result => !canceled && setResult(result),
       error => !canceled && setError(error)
     );
@@ -15,7 +29,7 @@ function usePromise(promise) {
     return () => {
       canceled = true;
     };
-  }, []);
+  }, [promise]);
 
   return [result, error];
 }

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -5,21 +5,17 @@ import usePromise from '.';
 const Test = ({ promise }) => {
   const [result, error] = usePromise(promise);
 
-  return (
-    <p>
-      {error || result}
-    </p>
-  );
+  return String(error || result);
 };
 
 test('should return the resolved value', async () => {
-  const app = <Test promise={() => Promise.resolve('foo')} />;
+  const app = <Test promise={Promise.resolve('foo')} />;
   const { container, rerender } = render(app);
 
   rerender(app);
 
   await wait(() => {
-    expect(container.firstChild.textContent).toBe('foo');
+    expect(container).toHaveTextContent('foo');
   });
 });
 
@@ -30,6 +26,17 @@ test('should return the rejected value', async () => {
   rerender(app);
 
   await wait(() => {
-    expect(container.firstChild.textContent).toBe('foo');
+    expect(container).toHaveTextContent('foo');
+  });
+});
+
+test('should return null if there is no promise', async () => {
+  const app = <Test />;
+  const { container, rerender } = render(app);
+
+  rerender(app);
+
+  await wait(() => {
+    expect(container).toHaveTextContent('null');
   });
 });


### PR DESCRIPTION
This adds support for rerunning `usePromise` when the promise changes by passing the promise in the `useEffect`'s `inputs` argument.
This also adds support for passing promises directly to `usePromise` and updates the tests, example and readme.