### PR TITLE
Add inputs array argument

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -8,6 +8,5 @@
 build
 coverage
 example
-jest-setup.js
 src
 yarn.lock

--- a/README.md
+++ b/README.md
@@ -42,12 +42,12 @@ import React, { useMemo } from 'react';
 import usePromise from 'react-use-promise';
 
 function Example() {
-  const [result, error, state] = usePromise(useMemo(
+  const [result, error, state] = usePromise(
     () => new Promise(resolve => {
       setTimeout(() => resolve('foo'), 2000);
     }),
     []
-  ));
+  );
 
   return (
     <div>
@@ -61,7 +61,10 @@ function Example() {
 ## API
 
 ```js
-usePromise<Result, Error>(Promise<Result, Error> | () => Promise<Result, Error>): [
+usePromise<Result, Error>(
+  Promise<Result, Error> | () => Promise<Result, Error>,
+  Array<any>
+): [
   Result,
   Error,
   'pending' | 'resolved' | 'rejected'
@@ -72,25 +75,26 @@ Receives a promise or a function that returns a promise and returns an array
 with the promise's result, error and state. The state is a string that can
 have one of three values: `'pending'`, `'resolved'` or `'rejected'`.
 
-**Note:** You'll probably want to avoid passing new promises on each render.
-This can happen if you do something like this:
+**Note:** You'll need to pass the inputs array to `usePromise`, otherwise
+this will try to resolve the promise on every render. For example:
 
 ```js
-const [response, error] = usePromise(fetch(url));
-```
-
-This will call `fetch` on every render, which will return a new promise each time.
-In this case, wrap the promise in `useMemo` or `useCallback`, so that you only pass
-a new promise when something changes. Example:
-
-```js
-const [response, error] = usePromise(useMemo(
+const [response, error] = usePromise(
   () => fetch(url),
   [url]
-));
+);
 ```
 
-This will only call `fetch` when the `url` changes.
+This will only call `fetch` again when the `url` changes.
+
+If you only want to resolve the promise once, pass an empty array, like this:
+
+```js
+const [result, error] = usePromise(
+  () => Notification.requestPermission(),
+  []
+);
+```
 
 ## Development
 

--- a/example/index.js
+++ b/example/index.js
@@ -1,14 +1,14 @@
 import { render } from 'react-dom';
-import React, { useMemo } from 'react';
+import React from 'react';
 import usePromise from '../src';
 
 const Example = () => {
-  const [result, error, state] = usePromise(useMemo(
+  const [result, error, state] = usePromise(
     () => new Promise(resolve => {
       setTimeout(() => resolve('foo'), 2000);
     }),
     []
-  ));
+  );
 
   return (
     <>

--- a/jest-setup.js
+++ b/jest-setup.js
@@ -1,1 +1,0 @@
-import 'jest-dom/extend-expect';

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "parcel-bundler": "^1.10.3",
     "react": "^16.8.2",
     "react-dom": "^16.8.2",
-    "react-testing-library": "^5.2.3",
+    "react-testing-library": "^5.8.0",
     "sort-package-json": "^1.18.0"
   },
   "peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -32,8 +32,7 @@
       "html",
       "lcov",
       "text"
-    ],
-    "setupTestFrameworkScriptFile": "./jest-setup.js"
+    ]
   },
   "devDependencies": {
     "@babel/cli": "^7.1.2",
@@ -47,7 +46,6 @@
     "eslint-config-seegno": "^11.0.1",
     "husky": "^1.3.1",
     "jest": "^23.6.0",
-    "jest-dom": "^2.1.0",
     "lint-staged": "^8.1.3",
     "parcel-bundler": "^1.10.3",
     "react": "^16.8.2",

--- a/src/index.js
+++ b/src/index.js
@@ -43,7 +43,7 @@ function reducer(state, action) {
   }
 }
 
-function usePromise(promise) {
+function usePromise(promise, inputs) {
   const [{ error, result, state }, dispatch] = useReducer(reducer, {
     error: null,
     result: null,
@@ -75,7 +75,7 @@ function usePromise(promise) {
     return () => {
       canceled = true;
     };
-  }, [promise]);
+  }, inputs);
 
   return [result, error, state];
 }

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -1,58 +1,131 @@
-import { cleanup, render, wait } from 'react-testing-library';
-import React from 'react';
+import { act, cleanup, testHook } from 'react-testing-library';
 import usePromise from '.';
 
-const Test = ({ promise }) => {
-  const [result, error, state] = usePromise(promise);
+class TestPromise {
 
-  return (
-    <>
-      <div>{state}</div>
-      <div>{String(result || error)}</div>
-    </>
-  );
-};
+  constructor() {
+    this.resolvers = new Set();
+    this.rejecters = new Set();
+  }
+
+  then(onResolve, onReject) {
+    if (onResolve) {
+      this.resolvers.add(onResolve);
+    }
+    if (onReject) {
+      this.rejecters.add(onReject);
+    }
+  }
+
+  catch(onReject) {
+    if (onReject) {
+      this.rejecters.add(onReject);
+    }
+  }
+
+  resolve(result) {
+    this.resolvers.forEach(resolver => resolver(result));
+  }
+
+  reject(error) {
+    this.rejecters.forEach(rejecter => rejecter(error));
+  }
+
+}
 
 afterEach(cleanup);
 
 test('should return a `pending` state while the promise is resolving', () => {
-  const app = <Test promise={Promise.resolve('foo')} />;
-  const { container } = render(app);
+  const promise = new TestPromise();
+  let state;
 
-  expect(container).toHaveTextContent('pending');
+  testHook(() => {
+    [,, state] = usePromise(promise, []);
+  });
+
+  expect(state).toBe('pending');
 });
 
-test('should return the resolved value', async () => {
-  const app = <Test promise={Promise.resolve('foo')} />;
-  const { container, rerender } = render(app);
+test('should return the resolved value', () => {
+  const promise = new TestPromise();
+  let state;
+  let result;
 
-  rerender(app);
-
-  await wait(() => {
-    expect(container).toHaveTextContent('resolved');
-    expect(container).toHaveTextContent('foo');
+  testHook(() => {
+    [result,, state] = usePromise(promise, []);
   });
+
+  expect(state).toBe('pending');
+
+  act(() => promise.resolve('foo'));
+
+  expect(state).toBe('resolved');
+  expect(result).toBe('foo');
 });
 
-test('should return the rejected value', async () => {
-  const app = <Test promise={() => Promise.reject('foo')} />;
-  const { container, rerender } = render(app);
+test('should return the rejected value', () => {
+  const promise = new TestPromise();
+  let state;
+  let error;
 
-  rerender(app);
-
-  await wait(() => {
-    expect(container).toHaveTextContent('rejected');
-    expect(container).toHaveTextContent('foo');
+  testHook(() => {
+    [, error, state] = usePromise(promise, []);
   });
+
+  act(() => promise.reject('foo'));
+
+  expect(state).toBe('rejected');
+  expect(error).toBe('foo');
 });
 
-test('should return null if there is no promise', async () => {
-  const app = <Test />;
-  const { container, rerender } = render(app);
+test('should return a null result if there is no promise', () => {
+  let result;
 
-  rerender(app);
-
-  await wait(() => {
-    expect(container).toHaveTextContent('null');
+  testHook(() => {
+    [result] = usePromise(null, []);
   });
+
+  expect(result).toBe(null);
+});
+
+test('should return to the pending state if the inputs change', () => {
+  const promise = new TestPromise();
+  let inputs = [false];
+  let state;
+
+  const { rerender } = testHook(() => {
+    [,, state] = usePromise(promise, inputs);
+  });
+
+  act(() => promise.resolve('foo'));
+  expect(state).toBe('resolved');
+
+  inputs = [true];
+  rerender();
+
+  expect(state).toBe('pending');
+});
+
+test('should call the callback', () => {
+  const callback = jest.fn(() => new TestPromise());
+
+  testHook(() => {
+    usePromise(callback, []);
+  });
+
+  expect(callback).toBeCalledTimes(1);
+});
+
+test('should call the callback again if the inputs change', () => {
+  const callback = jest.fn(() => new TestPromise());
+  let inputs = [false];
+
+  const { rerender } = testHook(() => {
+    usePromise(callback, inputs);
+  });
+
+  inputs = [true];
+  rerender();
+
+  expect(callback).toBeCalledTimes(2);
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -704,6 +704,13 @@
   dependencies:
     regenerator-runtime "^0.12.0"
 
+"@babel/runtime@^7.1.5", "@babel/runtime@^7.3.1":
+  version "7.3.1"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.3.1.tgz#574b03e8e8a9898eaf4a872a92ea20b7846f6f2a"
+  integrity sha512-7jGW8ppV0ant637pIqAcFfQDDH1orEPGJb8aXfUozuCU3QqX7rX4DA8iwrbPrR1hcH0FTTHz47yQnk+bl5xHQA==
+  dependencies:
+    regenerator-runtime "^0.12.0"
+
 "@babel/template@7.0.0-beta.44":
   version "7.0.0-beta.44"
   resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.0.0-beta.44.tgz#f8832f4fdcee5d59bf515e595fc5106c529b394f"
@@ -898,6 +905,11 @@ ansi-regex@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-3.0.0.tgz#ed0317c322064f79466c02966bddb605ab37d998"
   integrity sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=
+
+ansi-regex@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-4.0.0.tgz#70de791edf021404c3fd615aa89118ae0432e5a9"
+  integrity sha512-iB5Dda8t/UqpPI/IjsejXu5jOGDrzn41wJyljwPH65VCIbk6+1BzFIMJGFwTNrYXT1CrD+B4l19U7awiQ8rk7w==
 
 ansi-styles@^2.2.1:
   version "2.2.1"
@@ -2490,14 +2502,15 @@ dom-serializer@0:
     domelementtype "~1.1.1"
     entities "~1.1.1"
 
-dom-testing-library@^3.12.0:
-  version "3.12.0"
-  resolved "https://registry.yarnpkg.com/dom-testing-library/-/dom-testing-library-3.12.0.tgz#45c33124fe6a347410117802a367d3291514fe6f"
-  integrity sha512-eWykEDuKmffXOUKvv4IK00krvC4m+V2/y137M1YccWanUlfUzqS1+3eqm3GMC9qMqCJugfHWn6OpIaQd9rwqcw==
+dom-testing-library@^3.13.1:
+  version "3.16.7"
+  resolved "https://registry.yarnpkg.com/dom-testing-library/-/dom-testing-library-3.16.7.tgz#99490eeb7b2808463f2567c204e24bbd93bf921c"
+  integrity sha512-aa+uEArk6yeTtpkW8B4269cqaF4Kj7JhwlceK0UPABadz6ZGDdVYBXip4TSO/YSqdKc2KKmyp0ydaU93eM4AYA==
   dependencies:
+    "@babel/runtime" "^7.1.5"
     "@sheerun/mutationobserver-shim" "^0.3.2"
-    pretty-format "^23.6.0"
-    wait-for-expect "^1.0.0"
+    pretty-format "^24.0.0"
+    wait-for-expect "^1.1.0"
 
 domain-browser@^1.1.1:
   version "1.2.0"
@@ -6482,6 +6495,14 @@ pretty-format@^23.6.0:
     ansi-regex "^3.0.0"
     ansi-styles "^3.2.0"
 
+pretty-format@^24.0.0:
+  version "24.0.0"
+  resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-24.0.0.tgz#cb6599fd73ac088e37ed682f61291e4678f48591"
+  integrity sha512-LszZaKG665djUcqg5ZQq+XzezHLKrxsA86ZABTozp+oNhkdqa+tG2dX4qa6ERl5c/sRDrAa3lHmwnvKoP+OG/g==
+  dependencies:
+    ansi-regex "^4.0.0"
+    ansi-styles "^3.2.0"
+
 private@^0.1.6, private@^0.1.8:
   version "0.1.8"
   resolved "https://registry.yarnpkg.com/private/-/private-0.1.8.tgz#2381edb3689f7a53d653190060fcf822d2f368ff"
@@ -6664,12 +6685,13 @@ react-dom@^16.8.2:
     prop-types "^15.6.2"
     scheduler "^0.13.2"
 
-react-testing-library@^5.2.3:
-  version "5.2.3"
-  resolved "https://registry.yarnpkg.com/react-testing-library/-/react-testing-library-5.2.3.tgz#c3be44bfa5eb1ba2acc1fb218785c40ebbdfe8ed"
-  integrity sha512-Bw52++7uORuIQnL55lK/WQfppqAc9+8yFG4lWUp/kmSOvYDnt8J9oI5fNCfAGSQi9iIhAv9aNsI2G5rtid0nrA==
+react-testing-library@^5.8.0:
+  version "5.8.0"
+  resolved "https://registry.yarnpkg.com/react-testing-library/-/react-testing-library-5.8.0.tgz#b5163758b1ddfd2e15c3cd2790562a527a1bb0a5"
+  integrity sha512-cYOX8aUKea5ojFVXkhLbNEAq86nYqBlhKulJI/0v8JfwWyQm+kbyNKFfyci6b2qI4KUEvBYZKWx+zZWeYrYOOA==
   dependencies:
-    dom-testing-library "^3.12.0"
+    "@babel/runtime" "^7.3.1"
+    dom-testing-library "^3.13.1"
 
 react@^16.8.2:
   version "16.8.2"
@@ -8028,10 +8050,10 @@ w3c-hr-time@^1.0.1:
   dependencies:
     browser-process-hrtime "^0.1.2"
 
-wait-for-expect@^1.0.0:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/wait-for-expect/-/wait-for-expect-1.0.1.tgz#73ab346ed56ed2ef66c380a59fd623755ceac0ce"
-  integrity sha512-TPZMSxGWUl2DWmqdspLDEy97/S1Mqq0pzbh2A7jTq0WbJurUb5GKli+bai6ayeYdeWTF0rQNWZmUvCVZ9gkrfA==
+wait-for-expect@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/wait-for-expect/-/wait-for-expect-1.1.0.tgz#6607375c3f79d32add35cd2c87ce13f351a3d453"
+  integrity sha512-vQDokqxyMyknfX3luCDn16bSaRcOyH6gGuUXMIbxBLeTo6nWuEWYqMTT9a+44FmW8c2m6TRWBdNvBBjA1hwEKg==
 
 walker@~1.0.5:
   version "1.0.7"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2122,16 +2122,6 @@ css-what@^2.1.2:
   resolved "https://registry.yarnpkg.com/css-what/-/css-what-2.1.2.tgz#c0876d9d0480927d7d4920dcd72af3595649554d"
   integrity sha512-wan8dMWQ0GUeF7DGEPVjhHemVW/vy6xUYmFzRY8RYqgA0JtXC9rJmbScBjqSu6dg9q0lwPQy6ZAmJVr3PPTvqQ==
 
-css@^2.2.3:
-  version "2.2.4"
-  resolved "https://registry.yarnpkg.com/css/-/css-2.2.4.tgz#c646755c73971f2bba6a601e2cf2fd71b1298929"
-  integrity sha512-oUnjmWpy0niI3x/mPL8dVEI1l7MnG3+HHyRPHf+YFSbK+svOhXpmSOcDURUh2aOCgl2grzrOPt1nHLuCVFULLw==
-  dependencies:
-    inherits "^2.0.3"
-    source-map "^0.6.1"
-    source-map-resolve "^0.5.2"
-    urix "^0.1.0"
-
 cssesc@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/cssesc/-/cssesc-2.0.0.tgz#3b13bd1bb1cb36e1bcb5a4dcd27f54c5dcb35703"
@@ -4332,19 +4322,6 @@ jest-docblock@^23.2.0:
   dependencies:
     detect-newline "^2.1.0"
 
-jest-dom@^2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/jest-dom/-/jest-dom-2.1.0.tgz#ddd2c75d284ae0c9d17528cfd820727e964f8dd3"
-  integrity sha512-1kUVHGqvsJYK9u0sTAihDp9IRIwngMH7JghRaQWB6WluWf0/2L6MxTEE2U4x7aRN6H89bfPeCu8zjlO+/nBqgw==
-  dependencies:
-    chalk "^2.4.1"
-    css "^2.2.3"
-    jest-diff "^23.6.0"
-    jest-matcher-utils "^23.6.0"
-    lodash "^4.17.11"
-    pretty-format "^23.6.0"
-    redent "^2.0.0"
-
 jest-each@^23.6.0:
   version "23.6.0"
   resolved "https://registry.yarnpkg.com/jest-each/-/jest-each-23.6.0.tgz#ba0c3a82a8054387016139c733a05242d3d71575"
@@ -4929,7 +4906,7 @@ lodash.zipobject@^4.0.0:
   resolved "https://registry.yarnpkg.com/lodash.zipobject/-/lodash.zipobject-4.1.3.tgz#b399f5aba8ff62a746f6979bf20b214f964dbef8"
   integrity sha1-s5n1q6j/YqdG9peb8gshT5ZNvvg=
 
-lodash@^4.13.1, lodash@^4.17.10, lodash@^4.17.11, lodash@^4.17.4, lodash@^4.17.5, lodash@^4.2.0:
+lodash@^4.13.1, lodash@^4.17.10, lodash@^4.17.4, lodash@^4.17.5, lodash@^4.2.0:
   version "4.17.11"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.11.tgz#b39ea6229ef607ecd89e2c8df12536891cac9b8d"
   integrity sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==
@@ -6767,14 +6744,6 @@ realpath-native@^1.0.0:
   dependencies:
     util.promisify "^1.0.0"
 
-redent@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/redent/-/redent-2.0.0.tgz#c1b2007b42d57eb1389079b3c8333639d5e1ccaa"
-  integrity sha1-wbIAe0LVfrE4kHmzyDM2OdXhzKo=
-  dependencies:
-    indent-string "^3.0.0"
-    strip-indent "^2.0.0"
-
 reduce-css-calc@^1.2.6:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/reduce-css-calc/-/reduce-css-calc-1.3.0.tgz#747c914e049614a4c9cfbba629871ad1d2927716"
@@ -7315,7 +7284,7 @@ sort-package-json@^1.18.0:
     detect-indent "^5.0.0"
     sort-object-keys "^1.1.2"
 
-source-map-resolve@^0.5.0, source-map-resolve@^0.5.2:
+source-map-resolve@^0.5.0:
   version "0.5.2"
   resolved "https://registry.yarnpkg.com/source-map-resolve/-/source-map-resolve-0.5.2.tgz#72e2cc34095543e43b2c62b2c4c10d4a9054f259"
   integrity sha512-MjqsvNwyz1s0k81Goz/9vRBe9SZdB09Bdw+/zYyO+3CuPk6fouTaxscHkgtE8jKvf01kVfl8riHzERQ/kefaSA==
@@ -7579,11 +7548,6 @@ strip-eof@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/strip-eof/-/strip-eof-1.0.0.tgz#bb43ff5598a6eb05d89b59fcd129c983313606bf"
   integrity sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=
-
-strip-indent@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/strip-indent/-/strip-indent-2.0.0.tgz#5ef8db295d01e6ed6cbf7aab96998d7822527b68"
-  integrity sha1-XvjbKV0B5u1sv3qrlpmNeCJSe2g=
 
 strip-json-comments@^2.0.1, strip-json-comments@~2.0.1:
   version "2.0.1"


### PR DESCRIPTION
This PR adds the inputs array argument. This array will be passed as is to the underlying `useEffect` call, and can be used to tell the Effect when to run again.

This was necessary because we can only ["rely on useMemo as a performance optimization, not as a semantic guarantee"](https://reactjs.org/docs/hooks-reference.html#usememo).

This also updates `react-testing-library` and updates the tests to use `testHook` and `act`.