### PR TITLE
Update typescript definition

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,10 +1,10 @@
+type PendingState = [undefined, undefined, 'pending'];
+type ResolvedState<Result> = [Result, undefined, 'resolved'];
+type RejectedState = [undefined, Error, 'rejected'];
+
 declare function usePromise<Result = any>(
   promise: Promise<Result> | (() => Promise<Result>),
   deps?: Array<any>
-): [
-  Result,
-  Error,
-  'pending' | 'resolved' | 'rejected'
-];
+): PendingState | ResolvedState<Result> | RejectedState;
 
 export default usePromise;


### PR DESCRIPTION
When using typescript with ``--strictNullChecks``, the current definition means result[0] is not nullable (or ``undefined``able) so we can access it as object without null checks.
```typescript
const result = usePromise(Promise.resolve('foo'));
console.log(result[0].length); // This should cause "Object is possibly 'undefined'" compilation error but doesn't.
```
With this pr, the compilation error is thrown.

We can also with this pr
```typescript
const result = usePromise(Promise.resolve('foo'));
if (result[2] === 'resolved') {
  // type narrowed to [string, undefined, 'resolved'];
  console.log(result[0].length); // ok
} else {
  //console.log(result[0].length); // <- error: result[0] must be undefined
}
```