### PR TITLE
Fix: Pending dispatch causes unneccesary re-render

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -28,15 +28,16 @@ var states = {
   rejected: 'rejected',
   resolved: 'resolved'
 };
+var defaultState = {
+  error: undefined,
+  result: undefined,
+  state: states.pending
+};
 
 function reducer(state, action) {
   switch (action.type) {
     case states.pending:
-      return {
-        error: undefined,
-        result: undefined,
-        state: states.pending
-      };
+      return defaultState;
 
     case states.resolved:
       return {
@@ -60,11 +61,7 @@ function reducer(state, action) {
 }
 
 function usePromise(promise, inputs) {
-  var _useReducer = (0, _react.useReducer)(reducer, {
-    error: undefined,
-    result: undefined,
-    state: states.pending
-  }),
+  var _useReducer = (0, _react.useReducer)(reducer, defaultState),
       _useReducer2 = _slicedToArray(_useReducer, 2),
       _useReducer2$ = _useReducer2[0],
       error = _useReducer2$.error,

--- a/src/index.js
+++ b/src/index.js
@@ -14,14 +14,16 @@ const states = {
   resolved: 'resolved'
 };
 
+const defaultState = {
+  error: undefined,
+  result: undefined,
+  state: states.pending
+};
+
 function reducer(state, action) {
   switch (action.type) {
     case states.pending:
-      return {
-        error: undefined,
-        result: undefined,
-        state: states.pending
-      };
+      return defaultState;
 
     case states.resolved:
       return {
@@ -44,11 +46,7 @@ function reducer(state, action) {
 }
 
 function usePromise(promise, inputs) {
-  const [{ error, result, state }, dispatch] = useReducer(reducer, {
-    error: undefined,
-    result: undefined,
-    state: states.pending
-  });
+  const [{ error, result, state }, dispatch] = useReducer(reducer, defaultState);
 
   useEffect(() => {
     promise = resolvePromise(promise);


### PR DESCRIPTION
Hi,

I figured out since the initial state of the internal useReducer hook and the first pending dispatch state value are referentially different, although they are identically same, it causes an unnecessary re-render. 
With this pr, I store the pending state in a global constant (defaultState) so it won't cause extra re-renders anymore.
