### PR TITLE
Update react peer dependency version

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,6 +53,6 @@
     "sort-package-json": "^1.18.0"
   },
   "peerDependencies": {
-    "react": "^16.8.0 || ^17.0.2"
+    "react": "^16.8.0 || ^17.0.2 || ^18.0.0"
   }
 }


### PR DESCRIPTION
This adds React v18 to the peer dependency version range.

Closes https://github.com/bsonntag/react-use-promise/issues/51 